### PR TITLE
Initial alert interaction support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           /p:CoverletOutput="../coverage/" \
           /p:MergeWith="../coverage/coverage.json" \
           /p:CoverletOutputFormat=\"cobertura,json\" -m:1 \
-          --verbosity detailed
+          --verbosity normal
     # CODE COVERAGE
     - name: Generate code coverage report
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,8 @@ jobs:
           /p:CollectCoverage=true \
           /p:CoverletOutput="../coverage/" \
           /p:MergeWith="../coverage/coverage.json" \
-          /p:CoverletOutputFormat=\"cobertura,json\" -m:1
+          /p:CoverletOutputFormat=\"cobertura,json\" -m:1 \
+          --verbosity detailed
     # CODE COVERAGE
     - name: Generate code coverage report
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/docs/src/components/disclaimer/Disclaimer.astro
+++ b/docs/src/components/disclaimer/Disclaimer.astro
@@ -1,0 +1,13 @@
+<div class="disclaimer">
+  <p>* Whilst we strive to make your developer experience seamless, at times you may have to incur breaking changes from the StageZero framework, resulting in code changes.</p>
+</div>
+
+<style lang="scss">
+  .disclaimer {
+    margin: 2rem 0 !important;
+
+    > p {
+      font-size: 14px;
+    }
+  }
+</style>

--- a/docs/src/content/docs/guides/alert-interactions.mdx
+++ b/docs/src/content/docs/guides/alert-interactions.mdx
@@ -1,0 +1,52 @@
+---
+title: Interacting with Alerts
+description: A guide detailing how to interact with Web alerts using StageZero's test driver.
+sidebar:
+    order: 4
+---
+
+`StageZero` follows a similar approach to interacting with alerts to the likes of [Playwright](https://playwright.dev/dotnet/docs/dialogs) and [Puppeteer](https://pptr.dev/api/puppeteer.dialog). You can subscribe to the `OnAlert` event listener
+available in the `IDriverWeb` object. This allows you to have clear, concise alert handling and reduces the requirement for having to wait for an alert to appear in the browser.
+
+## Usage
+
+```csharp
+var driver = DriverBuilder.Create(new WebDriverOptions());
+driver.OnAlert += async (_, alert) => 
+{
+    // Handle any alert based actions here.
+};
+```
+
+> ⚠️ **Precautions**
+>
+> You must ensure that you handle the alert directly in the `OnAlert` event handler. If you do not call either `Dismiss` or `Confirm` your tests **will** hang.
+
+### Confirming an alert
+
+
+```csharp
+driver.OnAlert += async (_, alert) => 
+{
+    await alert.Confirm();
+};
+```
+
+### Dismissing an alert
+
+```csharp
+driver.OnAlert += async (_, alert) => 
+{
+    await alert.Dismiss();
+};
+```
+
+### Getting alert text
+
+```csharp
+driver.OnAlert += async (_, alert) =>
+{
+    Console.WriteLine(alert.Message);
+    await alert.Dismiss();
+}
+```

--- a/docs/src/content/docs/guides/executing-javascript.mdx
+++ b/docs/src/content/docs/guides/executing-javascript.mdx
@@ -2,7 +2,7 @@
 title: Executing JavaScript
 description: A guide detailing how to execute JavaScript using StageZero's test driver.
 sidebar:
-    order: 4
+    order: 5
 ---
 
 Sometimes it's necessary to execute JavaScript directly in the browser from your tests. 

--- a/docs/src/content/docs/guides/executing-javascript.mdx
+++ b/docs/src/content/docs/guides/executing-javascript.mdx
@@ -5,7 +5,7 @@ sidebar:
     order: 4
 ---
 
-Sometimes it's neccessary to execute JavaScript directly in the browser from your tests. 
+Sometimes it's necessary to execute JavaScript directly in the browser from your tests. 
 `StageZero` supplies a variety of utility commands to achieve this across our support WebDrivers.
 
 ## Running JavaScript

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,6 +19,7 @@ hero:
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import Disclaimer from '../../components/disclaimer/Disclaimer.astro';
 import Footer from '../../components/footer/Footer.astro';
 import SupportedDrivers from '../../components/supported-drivers/SupportedDrivers.astro';
 
@@ -41,21 +42,23 @@ Want to cut straight to the chase? Here are some of the main reasons to start us
 		StageZero is all about focusing on what matters, your tests! Focus on test creation, rather than writing and maintaining logic to steer the browser.
 	</Card>
 	<Card title="Write tests once" icon="puzzle">
-		Build your tests with confidence. You can migrate to and from an integration of your choosing (e.g. Selenium -> Playwright) with only one line of code. Your tests will always work. Your code won't change.
+		Build your tests with confidence. You can migrate to and from an integration of your choosing with ease. We don't punish you for changing WebDriver technology.*
 	</Card>
   <Card title="Minimal setup" icon="document">
-      Register your desired integration with our `DriverBuilder` and away you go. No more creating or maintaining separate framework code. StageZero allows you to focus on test creation, rather than browser interaction.
+    Register your desired integration with our `DriverBuilder` and away you go. No more creating or maintaining separate framework code. 
   </Card>
   <Card title="Streamlined interactions" icon="random">
-      It's never been easier to interact with elements. Execute a variety of actions with the call of a method.
+    It's never been easier to interact with elements. Execute a variety of actions with the call of a method.
   </Card>
   <Card title="Simple configuration" icon="setting">
-      Use one configuration across many integrations. You only need to deal with our `DriverOptions` in order to change test driver behaviours. We handle the rest.
+    Control any desired WebDriver behaviours (e.g. headless mode) with our `DriverOptions` configuration. We handle the rest.
   </Card>
   <Card title="Rock solid" icon="rocket">
-      All supported integrations are built with stability and parallelism in mind. Feel comfortable knowing you're on strong foundations.
+    All supported integrations are built with stability and parallelism in mind. Feel comfortable knowing you're on strong foundations.
   </Card>
 </CardGrid>
+
+<Disclaimer />
 
 <Footer />
 

--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -24,6 +24,7 @@ html {
 .action {
   padding: pxToRem(8) pxToRem(18);
   transition: all .125s ease-in-out;
+  line-height: 100%;
 
   &.primary {
     background-color: var(--sl-color-accent);

--- a/src/StageZero.IntegrationTests/TestBase.cs
+++ b/src/StageZero.IntegrationTests/TestBase.cs
@@ -16,6 +16,8 @@ public class TestBase
 
     public string? TestSitePath { get; private set; }
 
+    public bool Headless => AppSettings.Get<bool>("Headless");
+
     private readonly Type _driverBuilderType;
 
     public TestBase(Type driverBuilderType)
@@ -40,7 +42,7 @@ public class TestBase
         // Create the driver
         Driver = DriverBuilder.Create(new WebDriverOptions
         {
-            Headless = AppSettings.Get<bool>("Headless")
+            Headless = Headless
         });
 
         var rootDirectory = Directory.GetCurrentDirectory().Substring(0, Directory.GetCurrentDirectory().LastIndexOf("src"));

--- a/src/StageZero.IntegrationTests/Tests/DriverTests.cs
+++ b/src/StageZero.IntegrationTests/Tests/DriverTests.cs
@@ -46,4 +46,22 @@ public class DriverTests : TestBase
 
         Assert.That(string.IsNullOrEmpty(inputValue), Is.True);
     }
+
+
+    [Test]
+    public async Task CanOpenAlert() 
+    {
+        // Listen for alerts
+        Driver.OnAlert += async (_, alert) =>
+        {
+            Assert.That(alert.Message, Is.EqualTo("Alert opened!"));
+            await alert.Dismiss();
+        };
+
+        // Navigate through test
+        await Driver.Navigate().ToUrl(TestSitePath);
+
+        var alertButton = await Driver.GetElement("#test-alert-button");
+        await alertButton.Click();
+    }
 }

--- a/src/StageZero.IntegrationTests/Tests/DriverTests.cs
+++ b/src/StageZero.IntegrationTests/Tests/DriverTests.cs
@@ -3,9 +3,11 @@ namespace StageZero.IntegrationTests.Tests;
 public class DriverTests : TestBase
 {
     private const string UrlToNavigate = "https://www.google.com/";
+    private readonly Type _driverBuilderType;
 
     public DriverTests(Type driverBuilderType) : base(driverBuilderType)
     {
+        _driverBuilderType = driverBuilderType;
     }
 
     [Test(ExpectedResult = true)]
@@ -51,6 +53,12 @@ public class DriverTests : TestBase
     [Test]
     public async Task CanOpenAlert() 
     {
+        // TODO: Investigate Github actions issues running Selenium alert tests in headless mode.
+        if (_driverBuilderType == typeof(Selenium.WebDriverBuilder) && Headless)
+        {
+            Assert.Ignore("Selenium currently has issues interacting with alerts in headless Chrome within Github actions. Skipping...");
+        }
+
         // Listen for alerts
         Driver.OnAlert += async (_, alert) =>
         {

--- a/src/StageZero.Playwright/PlaywrightAlert.cs
+++ b/src/StageZero.Playwright/PlaywrightAlert.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+using StageZero.Web;
+using System.Threading.Tasks;
+
+namespace StageZero.Playwright;
+
+public class PlaywrightAlert : IAlert
+{
+    private readonly IDialog _dialog;
+
+    public PlaywrightAlert(IDialog dialog)
+    {
+        _dialog = dialog;
+    }
+
+    /// <inheritdoc/>
+    public string Message => _dialog.Message;
+
+    /// <inheritdoc/>
+    public Task Confirm()
+    {
+        return _dialog.AcceptAsync();
+    }
+
+    /// <inheritdoc/>
+    public Task Dismiss()
+    {
+        return _dialog.DismissAsync();
+    }
+}

--- a/src/StageZero.Playwright/PlaywrightNavigate.cs
+++ b/src/StageZero.Playwright/PlaywrightNavigate.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Playwright;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace StageZero.Playwright;

--- a/src/StageZero.Playwright/WebDriver.cs
+++ b/src/StageZero.Playwright/WebDriver.cs
@@ -2,6 +2,7 @@
 using StageZero.Web;
 using System;
 using System.Threading.Tasks;
+using static StageZero.Web.IDriverWeb;
 
 namespace StageZero.Playwright;
 
@@ -17,6 +18,8 @@ public class WebDriver : IDriverWeb
     private int _maxInitTries = 2;
 
     private readonly object lockObj = new();
+
+    public event HandleAlert OnAlert;
 
     public WebDriver(WebDriverOptions options)
     {
@@ -97,6 +100,11 @@ public class WebDriver : IDriverWeb
                 throw new NotSupportedException($"Sorry! Looks like the {options.Browser} isn't supported yet :/ - Feel free to check our github for updates!");
         }
 
+        _page.Dialog += (_, dialog) => 
+        {
+            OnAlert.Invoke(this, new PlaywrightAlert(dialog));
+        };
+
         await _browserContext.Tracing.StartAsync(new TracingStartOptions
         {
             Screenshots = true,
@@ -150,5 +158,11 @@ public class WebDriver : IDriverWeb
     public IWindow Window()
     {
         return new Window(_page);
+    }
+    
+    /// <inheritdoc/>
+    public INavigateContext SwitchContext()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/StageZero.Selenium/Browser/Implementations/FirefoxBrowserDriver.cs
+++ b/src/StageZero.Selenium/Browser/Implementations/FirefoxBrowserDriver.cs
@@ -1,5 +1,6 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Firefox;
+using System;
 using System.Collections.Generic;
 
 namespace StageZero.Selenium.Browser.Implementations;
@@ -18,7 +19,7 @@ internal class FirefoxBrowserDriver : BrowserDriver
 
         if (!string.IsNullOrEmpty(Options.EmulatedDeviceName))
         {
-#warning Mobile emulation is not supported in Firefox, please consider using an alternative supported browser (e.g. Chrome or Edge)
+            Console.WriteLine("Mobile emulation is not supported in Firefox, please consider using an alternative supported browser (e.g. Chrome or Edge)");
         }
 
         firefoxOptions.AddArguments(arguments);

--- a/src/StageZero.Selenium/Browser/Implementations/SafariBrowserDriver.cs
+++ b/src/StageZero.Selenium/Browser/Implementations/SafariBrowserDriver.cs
@@ -1,4 +1,5 @@
-﻿using OpenQA.Selenium;
+﻿using System;
+using OpenQA.Selenium;
 using OpenQA.Selenium.Safari;
 
 namespace StageZero.Selenium.Browser.Implementations;
@@ -10,12 +11,12 @@ internal class SafariBrowserDriver : BrowserDriver
         var safariOptions = new SafariOptions();
         if (Options.Headless)
         {
-#warning Headless mode is not supported in Safari, learn more at: https://github.com/SeleniumHQ/selenium/issues/5985
+            Console.WriteLine("Headless mode is not supported in Safari, learn more at: https://github.com/SeleniumHQ/selenium/issues/5985");
         }
 
         if (!string.IsNullOrEmpty(Options.EmulatedDeviceName))
         {
-#warning Mobile emulation is not supported in Firefox, please consider using an alternative supported browser (e.g. Chrome or Edge)
+            Console.WriteLine("Mobile emulation is not supported in Firefox, please consider using an alternative supported browser (e.g. Chrome or Edge)");
         }
 
         return new SafariDriver(

--- a/src/StageZero.Selenium/SeleniumAlert.cs
+++ b/src/StageZero.Selenium/SeleniumAlert.cs
@@ -1,4 +1,5 @@
 ﻿using StageZero.Web;
+using System;
 using System.Threading.Tasks;
 
 namespace StageZero.Selenium;
@@ -13,17 +14,49 @@ public class SeleniumAlert : IAlert
     }
 
     /// <inheritdoc/>
-    public string Message => _seleniumAlert.Text;
+    public string Message 
+    {
+        get
+        {
+            try
+            {
+                return _seleniumAlert.Text;
+            }
+            catch
+            {
+                Console.WriteLine("Something went wrong interacting with requested alert element. Perhaps it's already closed?");
+                return string.Empty;
+            }
+        }
+    }
 
     /// <inheritdoc/>
     public Task Confirm()
     {
-        return Task.Run(() => _seleniumAlert.Accept());
+        return Task.Run(() => {
+            try
+            {
+                _seleniumAlert.Accept();
+            } 
+            catch
+            {
+                Console.WriteLine("Something went wrong interacting with requested alert element. Perhaps it's already closed?");
+            }
+        });
     }
 
     /// <inheritdoc/>
     public Task Dismiss()
     {
-        return Task.Run(() => _seleniumAlert.Dismiss());
+        return Task.Run(() => {
+            try
+            {
+                _seleniumAlert.Dismiss();
+            }
+            catch
+            {
+                Console.WriteLine("Something went wrong interacting with requested alert element. Perhaps it's already closed?");
+            }
+        });
     }
 }

--- a/src/StageZero.Selenium/SeleniumAlert.cs
+++ b/src/StageZero.Selenium/SeleniumAlert.cs
@@ -1,0 +1,29 @@
+﻿using StageZero.Web;
+using System.Threading.Tasks;
+
+namespace StageZero.Selenium;
+
+public class SeleniumAlert : IAlert
+{
+    private readonly OpenQA.Selenium.IAlert _seleniumAlert;
+
+    public SeleniumAlert(OpenQA.Selenium.IAlert seleniumAlert)
+    {
+        _seleniumAlert = seleniumAlert;
+    }
+
+    /// <inheritdoc/>
+    public string Message => _seleniumAlert.Text;
+
+    /// <inheritdoc/>
+    public Task Confirm()
+    {
+        return Task.Run(() => _seleniumAlert.Accept());
+    }
+
+    /// <inheritdoc/>
+    public Task Dismiss()
+    {
+        return Task.Run(() => _seleniumAlert.Dismiss());
+    }
+}

--- a/src/StageZero.Selenium/SeleniumAlert.cs
+++ b/src/StageZero.Selenium/SeleniumAlert.cs
@@ -24,7 +24,7 @@ public class SeleniumAlert : IAlert
             }
             catch
             {
-                Console.WriteLine("Something went wrong interacting with requested alert element. Perhaps it's already closed?");
+                Console.WriteLine("Something went wrong interacting with the requested alert element. Perhaps it's already closed?");
                 return string.Empty;
             }
         }
@@ -40,7 +40,7 @@ public class SeleniumAlert : IAlert
             } 
             catch
             {
-                Console.WriteLine("Something went wrong interacting with requested alert element. Perhaps it's already closed?");
+                Console.WriteLine("Something went wrong interacting with the requested alert element. Perhaps it's already closed?");
             }
         });
     }
@@ -55,7 +55,7 @@ public class SeleniumAlert : IAlert
             }
             catch
             {
-                Console.WriteLine("Something went wrong interacting with requested alert element. Perhaps it's already closed?");
+                Console.WriteLine("Something went wrong interacting with the requested alert element. Perhaps it's already closed?");
             }
         });
     }

--- a/src/StageZero.Selenium/WebDriver.cs
+++ b/src/StageZero.Selenium/WebDriver.cs
@@ -46,7 +46,6 @@ public class WebDriver : IDriverWeb
                     // Switch back to the default page content
                     _seleniumDriver.SwitchTo().DefaultContent();
                 }
-                // No alert found
                 catch (NoAlertPresentException)
                 {
                 }

--- a/src/StageZero/Web/IAlert.cs
+++ b/src/StageZero/Web/IAlert.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+
+namespace StageZero.Web;
+
+public interface IAlert
+{
+    /// <summary>
+    /// The message content of the browser alert
+    /// </summary>
+    string Message { get; }
+
+    /// <summary>
+    /// Click the confirmation action of the browser alert
+    /// </summary>
+    Task Confirm();
+
+    /// <summary>
+    /// Click the dismiss action of the browser alert
+    /// </summary>
+    Task Dismiss();
+}

--- a/src/StageZero/Web/IDriverWeb.cs
+++ b/src/StageZero/Web/IDriverWeb.cs
@@ -48,4 +48,14 @@ public interface IDriverWeb : IDriver
     /// Terminate the current <see cref="IDriverWeb"/> instance.
     /// </summary>
     public Task Terminate();
+
+    /// <summary>
+    /// The <see cref="OnAlert"/> delegate handler.
+    /// </summary>
+    public delegate void HandleAlert(object sender, IAlert alert);
+
+    /// <summary>
+    /// An event handler used to subscribe to alert open events in the browser.
+    /// </summary>
+    public event HandleAlert OnAlert;
 }

--- a/src/StageZero/Web/INavigateContext.cs
+++ b/src/StageZero/Web/INavigateContext.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace StageZero.Web;
+
+public interface INavigateContext 
+{
+    /// <summary>
+    /// A browser based alert 
+    /// </summary>
+    /// <returns>An <see cref="IAlert"/> instance</returns>
+    IAlert Alert();
+}

--- a/test/demo-site/index.html
+++ b/test/demo-site/index.html
@@ -179,6 +179,12 @@
         </div>
       </div>
     </section>
+    
+    <section>
+      <h2>Navigation contexts</h2>
+
+      <button id="test-alert-button" onclick="alert('Alert opened!')">Open alert box</button>
+    </section>
 
     <section>
       <h2>Attributes</h2>


### PR DESCRIPTION
Addresses #21 and adds support for alert box interaction in the browser. You can subscribe to alert events like:

```csharp
var driver = DriverBuilder.Create(new WebDriverOptions());
driver.OnAlert += async (_, alert) => 
{
  // Do something with the alert
  await alert.Dismiss();
}
```

This way of subscribing and responding to browser alerts in a UI automated test framework is fairly rigid, and somewhat standard across some of the other web driver offerings.