### PR TITLE
Added support for getting elements and selecting from dropdowns

### DIFF
--- a/docs/src/content/docs/guides/element-interactions.mdx
+++ b/docs/src/content/docs/guides/element-interactions.mdx
@@ -12,6 +12,20 @@ That's pretty neat, but can sometimes be tricky to test! `StageZero` aims to rem
 
 Here are some common element interaction use cases driven by `StageZero`.
 
+### Getting an element
+
+```csharp
+var element = await Driver.GetElement("#element");
+```
+
+#### Getting elements
+
+Similar to the above snippet, you are also able to get a collection of HTML elements using:
+
+```csharp
+var elements = await Driver.GetElements("#element");
+```
+
 ### Clicking an element
 
 ```csharp
@@ -47,6 +61,22 @@ var elementToHold = await Driver.GetElement("#hold-element");
 var timeToHold = TimeSpan.FromSeconds(1);
 
 await elementToHold.ClickAndHold(timeToHold);
+```
+
+### Selecting an option from a dropdown
+
+#### Selecting an option based on its text contents
+
+```csharp
+var selectElement = await Driver.GetElement("#select-element");
+await selectElement.SelectOption("Value 1");
+```
+
+#### Selecting an option based on its index
+
+```csharp
+var selectElement = await Driver.GetElement("#select-element");
+await selectElement.SelectOption(1);
 ```
 
 ### Scrolling to an element

--- a/src/StageZero.IntegrationTests/Tests/ElementTests.cs
+++ b/src/StageZero.IntegrationTests/Tests/ElementTests.cs
@@ -14,6 +14,18 @@ public class ElementTests : TestBase
         Assert.That(bodyElement, Is.Not.Null);
     }
 
+    [Test]
+    public async Task CanGetElements()
+    {
+        var liElements = await Driver.GetElements("#test-list li");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(liElements, Is.Not.Null);
+            Assert.That(liElements.Count, Is.EqualTo(2));
+        });
+    }
+
     [TestCase("Testing 123")]
     public async Task CanType(string textToType)
     {
@@ -99,5 +111,25 @@ public class ElementTests : TestBase
         var scrollToElement = await scrollToContainer.ScrollTo("#test-scroll-success");
 
         Assert.That(scrollToElement, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task CanSelectOptionByText()
+    {
+        var selectElement = await Driver.GetElement("#test-select");
+        await selectElement.SelectOption("Value 1");
+
+        var selectValue = await selectElement.GetAttributeValue("value");
+        Assert.That(selectValue, Is.EqualTo("Value 1"));
+    }
+
+    [Test]
+    public async Task CanSelectOptionByIndex()
+    {
+        var selectElement = await Driver.GetElement("#test-select");
+        await selectElement.SelectOption(1);
+
+        var selectValue = await selectElement.GetAttributeValue("value");
+        Assert.That(selectValue, Is.EqualTo("Value 1"));
     }
 }

--- a/src/StageZero.Playwright/Extensions/LocatorExtensions.cs
+++ b/src/StageZero.Playwright/Extensions/LocatorExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Playwright;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StageZero.Playwright.Extensions;
+
+internal static class LocatorExtensions
+{
+    internal static async Task<IReadOnlyList<ILocator>> GetAllLocators(this IPage page, string cssSelector)
+    {
+        const int maxWaitTimeMs = 2500;
+        const int maxSearchAttempts = 10;
+        const int waitTime = maxWaitTimeMs / maxSearchAttempts;
+
+        IReadOnlyList<ILocator> locators = null;
+
+        var searchAttempts = 0;
+        while (locators == null && searchAttempts < maxSearchAttempts)
+        {
+            try
+            {
+                locators = await page.Locator(cssSelector).AllAsync();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"Attempt #{searchAttempts + 1}. Failed to find css selector {cssSelector}. Retrying...");
+            }
+            finally
+            {
+                searchAttempts += 1;
+
+                // Wait a couple of ms before retrying the search
+                await Task.Delay(waitTime);
+            }
+        }
+
+        if (locators == null)
+        {
+            throw new Exception($"Failed to find elements with css selector {cssSelector}");
+        }
+
+        return locators;
+    }
+}
+

--- a/src/StageZero.Playwright/WebDriver.cs
+++ b/src/StageZero.Playwright/WebDriver.cs
@@ -1,6 +1,10 @@
 ﻿using Microsoft.Playwright;
+using StageZero.Playwright.Extensions;
 using StageZero.Web;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using static StageZero.Web.IDriverWeb;
 
@@ -130,6 +134,13 @@ public class WebDriver : IDriverWeb
     }
 
     /// <inheritdoc/>
+    public async Task<IEnumerable<IElementWeb>> GetElements(string cssSelector)
+    {
+        var locators = await _page.GetAllLocators(cssSelector);
+        return locators.Select(locator => new WebElement(locator, _page, cssSelector));
+    }
+
+    /// <inheritdoc/>
     public INavigate Navigate()
     {
         return new PlaywrightNavigate(_page);
@@ -158,11 +169,5 @@ public class WebDriver : IDriverWeb
     public IWindow Window()
     {
         return new Window(_page);
-    }
-    
-    /// <inheritdoc/>
-    public INavigateContext SwitchContext()
-    {
-        throw new NotImplementedException();
     }
 }

--- a/src/StageZero.Playwright/WebElement.cs
+++ b/src/StageZero.Playwright/WebElement.cs
@@ -2,6 +2,7 @@
 using StageZero.Web;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace StageZero.Playwright;
@@ -148,5 +149,20 @@ public class WebElement : IElementWeb
         await scrollToElement.ScrollIntoViewIfNeededAsync();
 
         return new WebElement(scrollToElement, _page, cssSelector);
+    }
+
+    /// <inheritdoc/>
+    public async Task SelectOption(string optionText)
+    {
+        await _locator.SelectOptionAsync(new string[] { optionText });
+    }
+
+    /// <inheritdoc/>
+    public async Task SelectOption(int optionIndex)
+    {
+        await _locator.SelectOptionAsync(new SelectOptionValue
+        {
+            Index = optionIndex
+        });
     }
 }

--- a/src/StageZero.Selenium/Extensions/SeleniumWebDriverExtensions.cs
+++ b/src/StageZero.Selenium/Extensions/SeleniumWebDriverExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace StageZero.Selenium.Extensions;
@@ -13,6 +15,15 @@ internal static class SeleniumWebDriverExtensions
 
         return Task.Run(() =>
             webDriverWait.Until(driver => driver.FindElement(By.CssSelector(cssSelector)))
+        );
+    }
+
+    internal static Task<List<IWebElement>> GetElements(this IWebDriver driver, string cssSelector)
+    {
+        var webDriverWait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+
+        return Task.Run(() => 
+            webDriverWait.Until(driver => driver.FindElements(By.CssSelector(cssSelector)).ToList())
         );
     }
 }

--- a/src/StageZero.Selenium/StageZero.Selenium.csproj
+++ b/src/StageZero.Selenium/StageZero.Selenium.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Selenium.Support" Version="4.20.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
     <PackageReference Include="WordsToNumbers" Version="1.1.0" />
   </ItemGroup>

--- a/src/StageZero.Selenium/WebDriver.cs
+++ b/src/StageZero.Selenium/WebDriver.cs
@@ -2,6 +2,8 @@
 using StageZero.Selenium.Browser;
 using StageZero.Selenium.Extensions;
 using StageZero.Web;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using static StageZero.Web.IDriverWeb;
 
@@ -64,6 +66,16 @@ public class WebDriver : IDriverWeb
         {
             var element = await _seleniumDriver.GetElement(cssSelector);
             return (IElementWeb)new WebElement(_seleniumDriver, element);
+        });
+    }
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<IElementWeb>> GetElements(string cssSelector)
+    {
+        return Task.Run(async () =>
+        {
+            var elements = await _seleniumDriver.GetElements(cssSelector);
+            return (IEnumerable<IElementWeb>)elements.Select(element => new WebElement(_seleniumDriver, element));
         });
     }
 

--- a/src/StageZero.Selenium/WebElement.cs
+++ b/src/StageZero.Selenium/WebElement.cs
@@ -1,5 +1,6 @@
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Support.UI;
 using StageZero.Selenium.Extensions;
 using StageZero.Web;
 using System;
@@ -163,5 +164,23 @@ public class WebElement : IElementWeb
             var converter = new SimpleReplacementStrategy();
             return converter.ConvertWordsToNumbers(key.ToString());
         }
+    }
+
+    public Task SelectOption(string optionText)
+    {
+        return Task.Run(() =>
+        {
+            var selectElement = new SelectElement(_element);
+            selectElement.SelectByText(optionText);
+        });
+    }
+
+    public Task SelectOption(int optionIndex)
+    {
+        return Task.Run(() =>
+        {
+            var selectElement = new SelectElement(_element);
+            selectElement.SelectByIndex(optionIndex);
+        });
     }
 }

--- a/src/StageZero/Web/IDriverWeb.cs
+++ b/src/StageZero/Web/IDriverWeb.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace StageZero.Web;
@@ -20,6 +22,13 @@ public interface IDriverWeb : IDriver
     /// <param name="cssSelector">The css selector used to find the element</param>
     /// <returns>The targeted <see cref="IElementWeb"/> instance.</returns>
     Task<IElementWeb> GetElement(string cssSelector);
+
+    /// <summary>
+    /// Gets n amount of elements given the provided <see cref="cssSelector"/>
+    /// </summary>
+    /// <param name="cssSelector">The css selector used to find the elements</param>
+    /// <returns>An <see cref="IEnumerable"/> of <see cref="IElementWeb"/> instances.</returns>
+    Task<IEnumerable<IElementWeb>> GetElements(string cssSelector);
 
     /// <summary>
     /// Invoke a browser level navigation event

--- a/src/StageZero/Web/IElementWeb.cs
+++ b/src/StageZero/Web/IElementWeb.cs
@@ -60,4 +60,16 @@ public interface IElementWeb : IElement
     /// <param name="cssSelector">The element to scroll to</param>
     /// <returns>The targeted <see cref="IElementWeb"/> instance.</returns>
     public Task<IElementWeb> ScrollTo(string cssSelector);
+
+    /// <summary>
+    /// Clicks the dropdown and selects the specified <see cref="optionText"/>
+    /// </summary>
+    /// <param name="optionText">The option to select</param>
+    public Task SelectOption(string optionText);
+
+    /// <summary>
+    /// Clicks the dropdown and selects the specified <see cref="optionIndex"/>
+    /// </summary>
+    /// <param name="optionIndex">The option to select</param>
+    public Task SelectOption(int optionIndex);
 }

--- a/test/demo-site/index.html
+++ b/test/demo-site/index.html
@@ -145,8 +145,23 @@
     </div>
 
     <section>
+      <h2>Elements</h2>
+
+      <ul id="test-list">
+        <li>Element #1</li>
+        <li>Element #2</li>
+      </ul>
+    </section>
+
+    <section>
       <h2>Interactive Elements</h2>
       <input id="test-input" placeholder="Type text" type="text" />
+      <select id="test-select">
+        <option disabled selected>Select a value</option>
+        <option>Value 1</option>
+        <option>Value 2</option>
+        <option>Value 3</option>
+      </select>
 
       <button id="test-button" onclick="onClick(event)">
         Click me!


### PR DESCRIPTION
Addresses #81. You can now select items from a `<select>` element doing the following:

```csharp
var element = await Driver.GetElement("#my-select");
await element.SelectOption("Option text");

// OR

await element.SelectOption(1);
```

You can now also get an array of elements using the following:

```csharp
var elements = await Driver.GetElements("#my-element");
```