### PR TITLE
Switch to async methods for Selenium navigation

### DIFF
--- a/src/StageZero.Selenium/SeleniumNavigate.cs
+++ b/src/StageZero.Selenium/SeleniumNavigate.cs
@@ -14,27 +14,27 @@ namespace StageZero.Selenium
         }
 
         /// <inheritdoc/>
-        public Task Back()
+        public async Task Back()
         {
-            return Task.Run(() => _driver.Navigate().Back());
+            await _driver.Navigate().BackAsync();
         }
 
         /// <inheritdoc/>
-        public Task Forward()
+        public async Task Forward()
         {
-            return Task.Run(() => _driver.Navigate().Forward());
+            await _driver.Navigate().ForwardAsync();
         }
 
         /// <inheritdoc/>
-        public Task ToUrl(string url)
+        public async Task ToUrl(string url)
         {
-            return Task.Run(() => _driver.Navigate().GoToUrl(url));
+            await _driver.Navigate().GoToUrlAsync(url);
         }
 
         /// <inheritdoc/>
-        public Task ToUrl(Uri uri)
+        public async Task ToUrl(Uri uri)
         {
-            return Task.Run(() => _driver.Navigate().GoToUrl(uri));
+            await _driver.Navigate().GoToUrlAsync(uri);
         }
     }
 }

--- a/src/StageZero.Selenium/WebDriver.cs
+++ b/src/StageZero.Selenium/WebDriver.cs
@@ -86,9 +86,9 @@ public class WebDriver : IDriverWeb
     }
 
     /// <inheritdoc/>
-    public Task Refresh()
+    public async Task Refresh()
     {
-        return Task.Run(() => _seleniumDriver.Navigate().Refresh());
+        await _seleniumDriver.Navigate().RefreshAsync();
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Support for async methods for the Navigator methods was merged into Selenium in June. This PR uses those async methods instead of running sync methods in a `Task.Run `

related: https://github.com/SeleniumHQ/selenium/pull/14051